### PR TITLE
Fix composite signal calculation

### DIFF
--- a/signal_manager.py
+++ b/signal_manager.py
@@ -8,9 +8,13 @@ class SignalManager:
         self.signals[name] = signal_data
 
     def calculate_composite_signal(self, weights: dict):
-        self.signals['Composite_Signal'] = sum(
-            self.signals[col] * weight for col, weight in weights.items()
-        )
+        """Return DataFrame with a weighted composite signal column."""
+        missing = set(weights) - set(self.signals.columns)
+        if missing:
+            raise KeyError(f"Missing signal columns: {', '.join(missing)}")
+
+        weighted = self.signals[list(weights.keys())].mul(pd.Series(weights))
+        self.signals['Composite_Signal'] = weighted.sum(axis=1)
         return self.signals
 
     def add_new_indicator(self, indicator_class, data: pd.DataFrame, **kwargs):

--- a/signal_manager.py
+++ b/signal_manager.py
@@ -14,8 +14,9 @@ class SignalManager:
             raise KeyError(f"Missing signal columns: {', '.join(missing)}")
 
         weighted = self.signals[list(weights.keys())].mul(pd.Series(weights))
-        self.signals['Composite_Signal'] = weighted.sum(axis=1)
-        return self.signals
+        result = self.signals.copy()
+        result['Composite_Signal'] = weighted.sum(axis=1)
+        return result
 
     def add_new_indicator(self, indicator_class, data: pd.DataFrame, **kwargs):
         indicator = indicator_class(**kwargs)


### PR DESCRIPTION
## Summary
- improve `SignalManager.calculate_composite_signal` logic
- validate provided weights and compute weighted sum using pandas

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_b_686e8e02644c832091c5b5ca358dc0ff