### PR TITLE
Add GitHub action for Black formatting checks

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,22 @@
+name: Python formatting
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install black
+        run: |
+          python -m pip install --upgrade pip
+          pip install black
+      - name: Check formatting
+        run: black --check .

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # market-analytics
+
 market-analytics
+
+## Development
+
+This repository uses [Black](https://github.com/psf/black) to enforce
+consistent Python formatting. A GitHub Actions workflow runs `black --check`
+on every push and pull request to the `main` branch.
+
+To manually verify formatting locally, install Black and run:
+
+```bash
+pip install black
+black --check .
+```


### PR DESCRIPTION
## Summary
- add workflow to run `black --check`
- document how to run formatting checks locally

## Testing
- `black --check .` *(fails: would reformat)*

------
https://chatgpt.com/codex/tasks/task_b_687457da6fd08320a57381e52c00f44b