### PR TITLE
Add unit test for composite signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # market-analytics
 market-analytics
+
+## Running tests
+
+Install the required dependencies and execute the test suite with `pytest`:
+
+```bash
+pip install -r requirements.txt  # if you manage dependencies
+pytest
+```

--- a/tests/test_signal_manager.py
+++ b/tests/test_signal_manager.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from signal_manager import SignalManager
+
+@pytest.fixture
+def sample_df():
+    """Simple DataFrame with binary signals."""
+    return pd.DataFrame({
+        'sig1': [1, 0, 1],
+        'sig2': [0, 1, 0],
+        'sig3': [1, 1, 0],
+    })
+
+@pytest.fixture
+def manager(sample_df):
+    mgr = SignalManager()
+    for name in sample_df.columns:
+        mgr.add_signal(name, sample_df[name])
+    return mgr
+
+def test_calculate_composite_signal(manager):
+    weights = {'sig1': 0.5, 'sig2': 0.3, 'sig3': 0.2}
+    result = manager.calculate_composite_signal(weights)
+    expected = pd.Series([0.7, 0.5, 0.5], name='Composite_Signal')
+    pd.testing.assert_series_equal(result['Composite_Signal'], expected)


### PR DESCRIPTION
## Summary
- add pytest unit test for SignalManager.calculate_composite_signal
- document running pytest in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687459bd453c8320a15b3d4fbb2673a1