### PR TITLE
Fix add_new_indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ YAHOO_FINANCE_API_KEY=your_api_key_here
 
 1. Learn how to use `yfinance` for downloading historical data.
 2. Familiarize yourself with `pandas` for DataFrame operations.
-3. Experiment with adding or modifying indicators via `SignalManager.add_new_indicator`.
+3. Experiment with adding or modifying indicators via `SignalManager.add_new_indicator`,
+   which now accepts the name of the signal column to store.
 4. Consider adding tests or automation to improve reliability.
 5. Extend configuration (tickers, time ranges, weights) beyond the defaults in `main.py`.
 

--- a/signal_manager.py
+++ b/signal_manager.py
@@ -18,6 +18,15 @@ class SignalManager:
         result['Composite_Signal'] = weighted.sum(axis=1)
         return result
 
-    def add_new_indicator(self, indicator_class, data: pd.DataFrame, **kwargs):
+    def add_new_indicator(
+        self, indicator_class, data: pd.DataFrame, signal_column: str, **kwargs
+    ):
+        """Calculate an indicator and store its signal column."""
         indicator = indicator_class(**kwargs)
-        return indicator.calculate(data)
+        updated = indicator.calculate(data)
+
+        if signal_column not in updated:
+            raise KeyError(f"{signal_column} not found in indicator output")
+
+        self.add_signal(signal_column, updated[signal_column])
+        return updated


### PR DESCRIPTION
## Summary
- update README bullet point
- store signal column in `add_new_indicator`

## Testing
- `python -m py_compile *.py`
- `flake8`
- `pylint main.py indicators.py signal_manager.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687c34d50b188320bf7f7f68bf2b17a4