### PR TITLE
feat: add technical indicators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 node_modules/
- .DS_Store
+.DS_Store
+dist/

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { getOpenClose } from './polygonClient';
+import { getOpenClose, getSMA, getEMA, getMACD, getRSI } from './polygonClient';
 
 // tiny contract:
 // input: symbol (string) via CLI arg or default 'AAPL'
@@ -23,8 +23,19 @@ async function main(): Promise<void> {
     const data = await getOpenClose(symbol, date);
     console.log('Open/Close summary:');
     console.dir(data, { depth: null });
+
+    const [sma, ema, macd, rsi] = await Promise.all([
+      getSMA(symbol),
+      getEMA(symbol),
+      getMACD(symbol),
+      getRSI(symbol),
+    ]);
+    console.log('SMA:', sma);
+    console.log('EMA:', ema);
+    console.log('MACD:', macd);
+    console.log('RSI:', rsi);
   } catch (err: any) {
-    console.error('Error fetching open/close:', err?.message || err);
+    console.error('Error fetching market data:', err?.message || err);
     process.exitCode = 1;
   }
 }

--- a/src/polygonClient.ts
+++ b/src/polygonClient.ts
@@ -62,3 +62,103 @@ export async function getOpenClose(symbol: string, date: string): Promise<any> {
     throw err;
   }
 }
+
+// Technical indicators
+
+export async function getSMA(symbol: string, window = 50, timespan = 'day'): Promise<any> {
+  if (!symbol) throw new Error('symbol is required');
+  const apiKey = getApiKey();
+  const url = `${BASE}/v1/indicators/sma/${encodeURIComponent(symbol)}`;
+  try {
+    const res = await axios.get(url, {
+      params: { apiKey, timespan, window, series_type: 'close', limit: 1 },
+      timeout: 10000,
+    });
+    return res.data;
+  } catch (err: any) {
+    if (err.response) {
+      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
+      const e: any = new Error(msg);
+      e.status = err.response.status;
+      throw e;
+    }
+    throw err;
+  }
+}
+
+export async function getEMA(symbol: string, window = 50, timespan = 'day'): Promise<any> {
+  if (!symbol) throw new Error('symbol is required');
+  const apiKey = getApiKey();
+  const url = `${BASE}/v1/indicators/ema/${encodeURIComponent(symbol)}`;
+  try {
+    const res = await axios.get(url, {
+      params: { apiKey, timespan, window, series_type: 'close', limit: 1 },
+      timeout: 10000,
+    });
+    return res.data;
+  } catch (err: any) {
+    if (err.response) {
+      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
+      const e: any = new Error(msg);
+      e.status = err.response.status;
+      throw e;
+    }
+    throw err;
+  }
+}
+
+export async function getMACD(
+  symbol: string,
+  shortWindow = 12,
+  longWindow = 26,
+  signalWindow = 9,
+  timespan = 'day',
+): Promise<any> {
+  if (!symbol) throw new Error('symbol is required');
+  const apiKey = getApiKey();
+  const url = `${BASE}/v1/indicators/macd/${encodeURIComponent(symbol)}`;
+  try {
+    const res = await axios.get(url, {
+      params: {
+        apiKey,
+        timespan,
+        short_window: shortWindow,
+        long_window: longWindow,
+        signal_window: signalWindow,
+        series_type: 'close',
+        limit: 1,
+      },
+      timeout: 10000,
+    });
+    return res.data;
+  } catch (err: any) {
+    if (err.response) {
+      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
+      const e: any = new Error(msg);
+      e.status = err.response.status;
+      throw e;
+    }
+    throw err;
+  }
+}
+
+export async function getRSI(symbol: string, window = 14, timespan = 'day'): Promise<any> {
+  if (!symbol) throw new Error('symbol is required');
+  const apiKey = getApiKey();
+  const url = `${BASE}/v1/indicators/rsi/${encodeURIComponent(symbol)}`;
+  try {
+    const res = await axios.get(url, {
+      params: { apiKey, timespan, window, series_type: 'close', limit: 1 },
+      timeout: 10000,
+    });
+    return res.data;
+  } catch (err: any) {
+    if (err.response) {
+      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
+      const e: any = new Error(msg);
+      e.status = err.response.status;
+      throw e;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- fetch SMA, EMA, MACD and RSI from Polygon alongside daily open/close
- ignore build output in version control

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: POLYGON_API_KEY not set in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68a68c33c51883209d4a35c49306a691