### PR TITLE
feat: generate technical indicator signals

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
-import { getOpenClose, getSMA, getEMA, getMACD, getRSI } from './polygonClient';
+import { getOpenClose } from './polygonClient';
+import { generateSignals } from './signals';
 
 // tiny contract:
 // input: symbol (string) via CLI arg or default 'AAPL'
@@ -24,16 +25,8 @@ async function main(): Promise<void> {
     console.log('Open/Close summary:');
     console.dir(data, { depth: null });
 
-    const [sma, ema, macd, rsi] = await Promise.all([
-      getSMA(symbol),
-      getEMA(symbol),
-      getMACD(symbol),
-      getRSI(symbol),
-    ]);
-    console.log('SMA:', sma);
-    console.log('EMA:', ema);
-    console.log('MACD:', macd);
-    console.log('RSI:', rsi);
+    const signals = await generateSignals(symbol, date);
+    console.log('Signals:', signals);
   } catch (err: any) {
     console.error('Error fetching market data:', err?.message || err);
     process.exitCode = 1;

--- a/src/signals.ts
+++ b/src/signals.ts
@@ -1,0 +1,85 @@
+import { getOpenClose, getSMA, getEMA, getMACD, getRSI } from './polygonClient';
+
+export interface IndicatorSignal {
+  indicator: string;
+  signal: 'buy' | 'sell' | 'hold';
+  score: number; // 0 (neutral) to 100 (strong)
+}
+
+function previousDay(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export async function generateSignals(symbol: string, date = previousDay()): Promise<IndicatorSignal[]> {
+  const [oc, smaArr, emaArr, macdArr, rsiArr] = await Promise.all([
+    getOpenClose(symbol, date),
+    getSMA(symbol),
+    getEMA(symbol),
+    getMACD(symbol),
+    getRSI(symbol),
+  ]);
+
+  const price: number | undefined = oc?.close;
+  const signals: IndicatorSignal[] = [];
+
+  const rsiValue = rsiArr?.[0]?.value;
+  if (typeof rsiValue === 'number') {
+    if (rsiValue > 70) {
+      const score = Math.min(100, Math.round(((rsiValue - 70) / 30) * 100));
+      signals.push({ indicator: 'RSI', signal: 'sell', score });
+    } else if (rsiValue < 30) {
+      const score = Math.min(100, Math.round(((30 - rsiValue) / 30) * 100));
+      signals.push({ indicator: 'RSI', signal: 'buy', score });
+    } else {
+      signals.push({ indicator: 'RSI', signal: 'hold', score: 0 });
+    }
+  }
+
+  const smaValue = smaArr?.[0]?.value;
+  if (typeof smaValue === 'number' && typeof price === 'number') {
+    const diffPerc = ((price - smaValue) / smaValue) * 100;
+    const score = Math.min(100, Math.round(Math.abs(diffPerc)));
+    if (Math.abs(diffPerc) < 0.1) {
+      signals.push({ indicator: 'SMA', signal: 'hold', score: 0 });
+    } else if (diffPerc > 0) {
+      signals.push({ indicator: 'SMA', signal: 'buy', score });
+    } else {
+      signals.push({ indicator: 'SMA', signal: 'sell', score });
+    }
+  }
+
+  const emaValue = emaArr?.[0]?.value;
+  if (typeof emaValue === 'number' && typeof price === 'number') {
+    const diffPerc = ((price - emaValue) / emaValue) * 100;
+    const score = Math.min(100, Math.round(Math.abs(diffPerc)));
+    if (Math.abs(diffPerc) < 0.1) {
+      signals.push({ indicator: 'EMA', signal: 'hold', score: 0 });
+    } else if (diffPerc > 0) {
+      signals.push({ indicator: 'EMA', signal: 'buy', score });
+    } else {
+      signals.push({ indicator: 'EMA', signal: 'sell', score });
+    }
+  }
+
+  const macdVal = macdArr?.[0]?.macd;
+  const macdSignal = macdArr?.[0]?.signal;
+  if (typeof macdVal === 'number' && typeof macdSignal === 'number') {
+    const diff = macdVal - macdSignal;
+    const score = Math.min(100, Math.round(Math.abs(diff) * 100));
+    if (Math.abs(diff) < 0.01) {
+      signals.push({ indicator: 'MACD', signal: 'hold', score: 0 });
+    } else if (diff > 0) {
+      signals.push({ indicator: 'MACD', signal: 'buy', score });
+    } else {
+      signals.push({ indicator: 'MACD', signal: 'sell', score });
+    }
+  }
+
+  return signals;
+}
+


### PR DESCRIPTION
## Summary
- add `generateSignals` helper to compute buy/sell/hold grades for RSI, SMA, EMA and MACD
- log graded signals in CLI example

## Testing
- `npm install`
- `npm run test` *(fails: POLYGON_API_KEY not set in environment)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_b_68a6931f78d48320839836f58833ad44