### PR TITLE
feat: support full market snapshots and multi-ticker signals

### DIFF
--- a/src/polygonClient.ts
+++ b/src/polygonClient.ts
@@ -63,6 +63,27 @@ export async function getOpenClose(symbol: string, date: string): Promise<any> {
   }
 }
 
+export async function getSnapshots(tickers: string[]): Promise<any[]> {
+  if (!tickers || tickers.length === 0) throw new Error('tickers array is required');
+  const apiKey = getApiKey();
+  const url = `${BASE}/v2/snapshot/locale/us/markets/stocks/tickers`;
+  try {
+    const res = await axios.get(url, {
+      params: { apiKey, tickers: tickers.join(',') },
+      timeout: 10000,
+    });
+    return res.data?.tickers ?? [];
+  } catch (err: any) {
+    if (err.response) {
+      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
+      const e: any = new Error(msg);
+      e.status = err.response.status;
+      throw e;
+    }
+    throw err;
+  }
+}
+
 // Technical indicators
 
 export async function getSMA(symbol: string, window = 50, timespan = 'day'): Promise<any> {

--- a/src/signals.ts
+++ b/src/signals.ts
@@ -1,4 +1,4 @@
-import { getOpenClose, getSMA, getEMA, getMACD, getRSI } from './polygonClient';
+import { getSMA, getEMA, getMACD, getRSI } from './polygonClient';
 
 export interface IndicatorSignal {
   indicator: string;
@@ -6,25 +6,13 @@ export interface IndicatorSignal {
   score: number; // 0 (neutral) to 100 (strong)
 }
 
-function previousDay(): string {
-  const d = new Date();
-  d.setDate(d.getDate() - 1);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
-
-export async function generateSignals(symbol: string, date = previousDay()): Promise<IndicatorSignal[]> {
-  const [oc, smaArr, emaArr, macdArr, rsiArr] = await Promise.all([
-    getOpenClose(symbol, date),
+export async function generateSignals(symbol: string, price: number): Promise<IndicatorSignal[]> {
+  const [smaArr, emaArr, macdArr, rsiArr] = await Promise.all([
     getSMA(symbol),
     getEMA(symbol),
     getMACD(symbol),
     getRSI(symbol),
   ]);
-
-  const price: number | undefined = oc?.close;
   const signals: IndicatorSignal[] = [];
 
   const rsiValue = rsiArr?.[0]?.value;


### PR DESCRIPTION
## Summary
- add `getSnapshots` for fetching full market snapshots for multiple tickers
- generate indicator signals using snapshot price
- allow CLI to accept comma-separated tickers and process concurrently

## Testing
- `npm test` *(fails: POLYGON_API_KEY not set in environment)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_b_68a69960a8908320b6b16d97c4faff69