### PR TITLE
feat: fetch tickers list from polygon

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { getOpenClose } from './polygonClient';
+import { getOpenClose, listTickers } from './polygonClient';
 import { generateSignals } from './signals';
 
 // tiny contract:
@@ -17,16 +17,19 @@ function previousDay(): string {
 }
 
 async function main(): Promise<void> {
-  const symbol = 'AAPL';
   const date = previousDay();
-  console.log(`Fetching open/close for: ${symbol} on ${date}`);
+  console.log(`Fetching tickers and market data for ${date}`);
   try {
-    const data = await getOpenClose(symbol, date);
-    console.log('Open/Close summary:');
-    console.dir(data, { depth: null });
+    const tickers = await listTickers(5, { market: 'stocks', active: true });
+    console.log('Tickers:', tickers);
+    for (const symbol of tickers) {
+      const data = await getOpenClose(symbol, date);
+      console.log(`Open/Close summary for ${symbol}:`);
+      console.dir(data, { depth: null });
 
-    const signals = await generateSignals(symbol, date);
-    console.log('Signals:', signals);
+      const signals = await generateSignals(symbol, date);
+      console.log(`Signals for ${symbol}:`, signals);
+    }
   } catch (err: any) {
     console.error('Error fetching market data:', err?.message || err);
     process.exitCode = 1;

--- a/src/polygonClient.ts
+++ b/src/polygonClient.ts
@@ -8,6 +8,27 @@ function getApiKey(): string {
   return k;
 }
 
+export async function listTickers(limit = 100, params: Record<string, any> = {}): Promise<string[]> {
+  const apiKey = getApiKey();
+  const url = `${BASE}/v3/reference/tickers`;
+  try {
+    const res = await axios.get(url, {
+      params: { apiKey, limit, ...params },
+      timeout: 10000,
+    });
+    const results = res.data?.results ?? [];
+    return results.map((t: any) => t.ticker);
+  } catch (err: any) {
+    if (err.response) {
+      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
+      const e: any = new Error(msg);
+      e.status = err.response.status;
+      throw e;
+    }
+    throw err;
+  }
+}
+
 export async function getTicker(ticker: string): Promise<any> {
   if (!ticker) throw new Error('ticker is required');
   const apiKey = getApiKey();


### PR DESCRIPTION
## Summary
- add listTickers helper to retrieve symbols from Polygon API
- iterate over fetched symbols to pull open/close data and generate signals

## Testing
- `POLYGON_API_KEY=demo npm run test` *(fails: Maximum number of redirects exceeded)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_b_68a6a44e7f4883209c292d5d088bf276