### PR TITLE
feat: fetch tickers from polygon

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import 'dotenv/config';
 import { generateSignals, IndicatorSignal } from './signals';
+import { listTickers } from './polygonClient';
 
 // tiny contract:
-// input: none – uses a fixed array of tickers
+// input: none – fetches an array of tickers from Polygon.io
 // output: prints indicator signals for each ticker and
 //         lists the best tickers to buy based on aggregated scores
 
@@ -24,7 +25,7 @@ function aggregateSignalScore(signals: IndicatorSignal[]): number {
 }
 
 async function main(): Promise<void> {
-  const tickers = ['AAPL', 'MSFT', 'GOOGL'];
+  const tickers = await listTickers(3);
   const date = previousDay();
   console.log(`Generating signals for ${tickers.join(', ')} on ${date}`);
   try {

--- a/src/polygonClient.ts
+++ b/src/polygonClient.ts
@@ -8,6 +8,26 @@ function getApiKey(): string {
   return k;
 }
 
+export async function listTickers(limit = 3): Promise<string[]> {
+  const apiKey = getApiKey();
+  const url = `${BASE}/v3/reference/tickers`;
+  try {
+    const res = await axios.get(url, {
+      params: { apiKey, market: 'stocks', active: true, limit },
+      timeout: 10000,
+    });
+    return res.data?.results?.map((t: any) => t.ticker) ?? [];
+  } catch (err: any) {
+    if (err.response) {
+      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
+      const e: any = new Error(msg);
+      e.status = err.response.status;
+      throw e;
+    }
+    throw err;
+  }
+}
+
 export async function getTicker(ticker: string): Promise<any> {
   if (!ticker) throw new Error('ticker is required');
   const apiKey = getApiKey();


### PR DESCRIPTION
## Summary
- retrieve a list of tickers from Polygon and use it to generate signals
- add Polygon client helper for listing tickers

## Testing
- `npx tsc -p tsconfig.json`
- `npm run test` *(fails: POLYGON_API_KEY not set in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68a6a98f59948320b1b03f92744dbb6c