### PR TITLE
feat: add short interest signals

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,10 @@ async function main(): Promise<void> {
  'TSLA','WMT','JPM','TV','CMS','PDD','LLY','V','ORCL','HDB',
  'BP','MA','NFLX','XOM','COST','JNJ','NTES','HD','CX','PLTR',
  'PG','EC','ABBV','BAC','CHT','NGG','SAP','CVX','KO','TMUS',
- 'ASML','BCS','VOD','UNH','BHP','AMD','LYG','CSCO','PM','DEO'];
+ 'ASML','BCS','VOD','UNH','BHP','AMD','LYG','CSCO','PM','DEO',
+ 'AMC', 'GME', 'HITI', 'RKLB', 'BULL', 'APLD', 'EOSE', 'UROY',
+ 'COIN', 'BKNG', 'SMR', 'BABA', 'AMD', 'IBM', 'HYMC', 'INTC',
+ 'CRON', 'TLRY', 'CGC', 'ACB', 'SNDL', 'CRM', 'TSM'];
   const date = previousDay();
   console.log(`Generating signals for ${tickers.join(', ')} on ${date}`);
   try {

--- a/src/polygonClient.ts
+++ b/src/polygonClient.ts
@@ -240,10 +240,15 @@ export async function get52WeekHighLow(symbol: string, toDate: string): Promise<
 export async function getShortInterest(ticker: string): Promise<any> {
   if (!ticker) throw new Error('ticker is required');
   const apiKey = getApiKey();
-  const url = `${BASE}/v3/reference/short_interest/${encodeURIComponent(ticker)}`;
+  // Polygon docs: https://polygon.io/docs/rest/stocks/fundamentals/short-interest
+  const url = `${BASE}/stocks/v1/short-interest`;
   try {
-    const res = await axios.get(url, { params: { apiKey, limit: 1 }, timeout: 10000 });
-    return res.data?.results?.[0] ?? null;
+    const res = await axios.get(url, {
+      params: { apiKey, ticker },
+      timeout: 10000,
+    });
+    const results = res.data?.results;
+    return Array.isArray(results) ? results[0] ?? null : results ?? null;
   } catch (err: any) {
     if (err.response) {
       const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
@@ -259,10 +264,15 @@ export async function getShortVolume(ticker: string, date: string): Promise<any>
   if (!ticker) throw new Error('ticker is required');
   if (!date) throw new Error('date is required (YYYY-MM-DD)');
   const apiKey = getApiKey();
-  const url = `${BASE}/v2/reference/short_volume/${encodeURIComponent(ticker)}`;
+  // Polygon docs: https://polygon.io/docs/rest/stocks/fundamentals/short-volume
+  const url = `${BASE}/stocks/v1/short-volume`;
   try {
-    const res = await axios.get(url, { params: { apiKey, date }, timeout: 10000 });
-    return res.data;
+    const res = await axios.get(url, {
+      params: { apiKey, ticker, date },
+      timeout: 10000,
+    });
+    const results = res.data?.results;
+    return Array.isArray(results) ? results[0] ?? null : results ?? null;
   } catch (err: any) {
     if (err.response) {
       const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;

--- a/src/polygonClient.ts
+++ b/src/polygonClient.ts
@@ -234,3 +234,42 @@ export async function get52WeekHighLow(symbol: string, toDate: string): Promise<
     throw err;
   }
 }
+
+// Short interest and short volume
+
+export async function getShortInterest(ticker: string): Promise<any> {
+  if (!ticker) throw new Error('ticker is required');
+  const apiKey = getApiKey();
+  const url = `${BASE}/v3/reference/short_interest/${encodeURIComponent(ticker)}`;
+  try {
+    const res = await axios.get(url, { params: { apiKey, limit: 1 }, timeout: 10000 });
+    return res.data?.results?.[0] ?? null;
+  } catch (err: any) {
+    if (err.response) {
+      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
+      const e: any = new Error(msg);
+      e.status = err.response.status;
+      throw e;
+    }
+    throw err;
+  }
+}
+
+export async function getShortVolume(ticker: string, date: string): Promise<any> {
+  if (!ticker) throw new Error('ticker is required');
+  if (!date) throw new Error('date is required (YYYY-MM-DD)');
+  const apiKey = getApiKey();
+  const url = `${BASE}/v2/reference/short_volume/${encodeURIComponent(ticker)}`;
+  try {
+    const res = await axios.get(url, { params: { apiKey, date }, timeout: 10000 });
+    return res.data;
+  } catch (err: any) {
+    if (err.response) {
+      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
+      const e: any = new Error(msg);
+      e.status = err.response.status;
+      throw e;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- fetch short interest and short volume from Polygon API
- include short interest and volume indicators when generating signals

## Testing
- `npm test` *(fails: timeout of 10000ms exceeded)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_b_68a74e309304832080ecd919361f47c9