### PR TITLE
refactor: centralize Polygon API GET helper

### DIFF
--- a/src/polygonClient.ts
+++ b/src/polygonClient.ts
@@ -19,15 +19,19 @@ function getApiKey(): string {
   return k;
 }
 
-export async function listTickers(limit = 3): Promise<string[]> {
+/**
+ * Helper to perform a GET request against the Polygon API with common settings
+ * and error handling. Automatically attaches the API key and request timeout.
+ */
+async function polygonGet(path: string, params: Record<string, any> = {}): Promise<any> {
   const apiKey = getApiKey();
-  const url = `${BASE}/v3/reference/tickers`;
+  const url = `${BASE}${path}`;
   try {
     const res = await axios.get(url, {
-      params: { apiKey, market: 'stocks', active: true, limit },
+      params: { apiKey, ...params },
       timeout: REQUEST_TIMEOUT,
     });
-    return res.data?.results?.map((t: any) => t.ticker) ?? [];
+    return res.data;
   } catch (err: any) {
     if (err.response) {
       const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
@@ -37,107 +41,55 @@ export async function listTickers(limit = 3): Promise<string[]> {
     }
     throw err;
   }
+}
+
+export async function listTickers(limit = 3): Promise<string[]> {
+  const data = await polygonGet('/v3/reference/tickers', {
+    market: 'stocks',
+    active: true,
+    limit,
+  });
+  return data?.results?.map((t: any) => t.ticker) ?? [];
 }
 
 export async function getTicker(ticker: string): Promise<any> {
   if (!ticker) throw new Error('ticker is required');
-  const apiKey = getApiKey();
-  const url = `${BASE}/v3/reference/tickers/${encodeURIComponent(ticker)}`;
-  try {
-  const res = await axios.get(url, { params: { apiKey }, timeout: REQUEST_TIMEOUT });
-    return res.data;
-  } catch (err: any) {
-    if (err.response) {
-      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
-      const e: any = new Error(msg);
-      e.status = err.response.status;
-      throw e;
-    }
-    throw err;
-  }
+  return polygonGet(`/v3/reference/tickers/${encodeURIComponent(ticker)}`);
 }
 
 export async function fetchLastTrade(symbol: string): Promise<any> {
   if (!symbol) throw new Error('symbol is required');
-  const apiKey = getApiKey();
-  const url = `${BASE}/v2/last/trade/${encodeURIComponent(symbol)}`;
-  try {
-  const res = await axios.get(url, { params: { apiKey }, timeout: REQUEST_TIMEOUT });
-    return res.data;
-  } catch (err: any) {
-    if (err.response) {
-      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
-      const e: any = new Error(msg);
-      e.status = err.response.status;
-      throw e;
-    }
-    throw err;
-  }
+  return polygonGet(`/v2/last/trade/${encodeURIComponent(symbol)}`);
 }
 
 export async function getOpenClose(symbol: string, date: string): Promise<any> {
   if (!symbol) throw new Error('symbol is required');
   if (!date) throw new Error('date is required (YYYY-MM-DD)');
-  const apiKey = getApiKey();
-  const url = `${BASE}/v1/open-close/${encodeURIComponent(symbol)}/${encodeURIComponent(date)}`;
-  try {
-  const res = await axios.get(url, { params: { apiKey }, timeout: REQUEST_TIMEOUT });
-    return res.data;
-  } catch (err: any) {
-    if (err.response) {
-      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
-      const e: any = new Error(msg);
-      e.status = err.response.status;
-      throw e;
-    }
-    throw err;
-  }
+  return polygonGet(`/v1/open-close/${encodeURIComponent(symbol)}/${encodeURIComponent(date)}`);
 }
 
 // Technical indicators
 
 export async function getSMA(symbol: string, window = 50, timespan = 'day'): Promise<any> {
   if (!symbol) throw new Error('symbol is required');
-  const apiKey = getApiKey();
-  const url = `${BASE}/v1/indicators/sma/${encodeURIComponent(symbol)}`;
-  try {
-    const res = await axios.get(url, {
-      params: { apiKey, timespan, window, series_type: 'close', limit: 1 },
-      timeout: REQUEST_TIMEOUT,
-    });
-    // return only the values array/object from the API response
-    return res.data?.results?.values ?? [];
-  } catch (err: any) {
-    if (err.response) {
-      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
-      const e: any = new Error(msg);
-      e.status = err.response.status;
-      throw e;
-    }
-    throw err;
-  }
+  const data = await polygonGet(`/v1/indicators/sma/${encodeURIComponent(symbol)}`, {
+    timespan,
+    window,
+    series_type: 'close',
+    limit: 1,
+  });
+  return data?.results?.values ?? [];
 }
 
 export async function getEMA(symbol: string, window = 50, timespan = 'day'): Promise<any> {
   if (!symbol) throw new Error('symbol is required');
-  const apiKey = getApiKey();
-  const url = `${BASE}/v1/indicators/ema/${encodeURIComponent(symbol)}`;
-  try {
-    const res = await axios.get(url, {
-      params: { apiKey, timespan, window, series_type: 'close', limit: 1 },
-      timeout: REQUEST_TIMEOUT,
-    });
-    // return only the values array/object from the API response
-    return res.data?.results?.values ?? [];
-  } catch (err: any) {
-    if (err.response) {
-      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
-      const e: any = new Error(msg);
-      e.status = err.response.status;
-      throw e;
-    }
-    throw err;
-  }
+  const data = await polygonGet(`/v1/indicators/ema/${encodeURIComponent(symbol)}`, {
+    timespan,
+    window,
+    series_type: 'close',
+    limit: 1,
+  });
+  return data?.results?.values ?? [];
 }
 
 export async function getMACD(
@@ -148,54 +100,26 @@ export async function getMACD(
   timespan = 'day',
 ): Promise<any> {
   if (!symbol) throw new Error('symbol is required');
-  const apiKey = getApiKey();
-  const url = `${BASE}/v1/indicators/macd/${encodeURIComponent(symbol)}`;
-  try {
-    const res = await axios.get(url, {
-      params: {
-        apiKey,
-        timespan,
-        short_window: shortWindow,
-        long_window: longWindow,
-        signal_window: signalWindow,
-        series_type: 'close',
-        limit: 1,
-      },
-      timeout: REQUEST_TIMEOUT,
-    });
-    // return only the values array/object from the API response
-    return res.data?.results?.values ?? [];
-  } catch (err: any) {
-    if (err.response) {
-      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
-      const e: any = new Error(msg);
-      e.status = err.response.status;
-      throw e;
-    }
-    throw err;
-  }
+  const data = await polygonGet(`/v1/indicators/macd/${encodeURIComponent(symbol)}`, {
+    timespan,
+    short_window: shortWindow,
+    long_window: longWindow,
+    signal_window: signalWindow,
+    series_type: 'close',
+    limit: 1,
+  });
+  return data?.results?.values ?? [];
 }
 
 export async function getRSI(symbol: string, window = 14, timespan = 'day'): Promise<any> {
   if (!symbol) throw new Error('symbol is required');
-  const apiKey = getApiKey();
-  const url = `${BASE}/v1/indicators/rsi/${encodeURIComponent(symbol)}`;
-  try {
-    const res = await axios.get(url, {
-      params: { apiKey, timespan, window, series_type: 'close', limit: 1 },
-      timeout: REQUEST_TIMEOUT,
-    });
-    // return only the values array/object from the API response
-    return res.data?.results?.values ?? [];
-  } catch (err: any) {
-    if (err.response) {
-      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
-      const e: any = new Error(msg);
-      e.status = err.response.status;
-      throw e;
-    }
-    throw err;
-  }
+  const data = await polygonGet(`/v1/indicators/rsi/${encodeURIComponent(symbol)}`, {
+    timespan,
+    window,
+    series_type: 'close',
+    limit: 1,
+  });
+  return data?.results?.values ?? [];
 }
 
 /**
@@ -205,7 +129,6 @@ export async function getRSI(symbol: string, window = 14, timespan = 'day'): Pro
 export async function get52WeekHighLow(symbol: string, toDate: string): Promise<{ high: number; low: number } | null> {
   if (!symbol) throw new Error('symbol is required');
   if (!toDate) throw new Error('toDate is required (YYYY-MM-DD)');
-  const apiKey = getApiKey();
   // compute from date ~365 days before toDate
   const to = new Date(toDate);
   const from = new Date(to);
@@ -214,85 +137,42 @@ export async function get52WeekHighLow(symbol: string, toDate: string): Promise<
   const fromStr = `${from.getFullYear()}-${pad(from.getMonth() + 1)}-${pad(from.getDate())}`;
   const toStr = `${to.getFullYear()}-${pad(to.getMonth() + 1)}-${pad(to.getDate())}`;
 
-  const url = `${BASE}/v2/aggs/ticker/${encodeURIComponent(symbol)}/range/1/day/${encodeURIComponent(fromStr)}/${encodeURIComponent(toStr)}`;
-  try {
-    const res = await axios.get(url, {
-      params: { apiKey, adjusted: true, limit: 1000 },
-      timeout: REQUEST_TIMEOUT,
-    });
+  const data = await polygonGet(
+    `/v2/aggs/ticker/${encodeURIComponent(symbol)}/range/1/day/${encodeURIComponent(fromStr)}/${encodeURIComponent(toStr)}`,
+    { adjusted: true, limit: 1000 },
+  );
 
-    const results = res.data?.results ?? [];
-    if (!Array.isArray(results) || results.length === 0) return null;
+  const results = data?.results ?? [];
+  if (!Array.isArray(results) || results.length === 0) return null;
 
-    let high = Number.NEGATIVE_INFINITY;
-    let low = Number.POSITIVE_INFINITY;
-    for (const r of results) {
-      const h = Number(r.h);
-      const l = Number(r.l);
-      if (Number.isFinite(h) && h > high) high = h;
-      if (Number.isFinite(l) && l < low) low = l;
-    }
-
-    if (!Number.isFinite(high) || !Number.isFinite(low)) return null;
-    return { high, low };
-  } catch (err: any) {
-    if (err.response) {
-      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
-      const e: any = new Error(msg);
-      e.status = err.response.status;
-      throw e;
-    }
-    throw err;
+  let high = Number.NEGATIVE_INFINITY;
+  let low = Number.POSITIVE_INFINITY;
+  for (const r of results) {
+    const h = Number(r.h);
+    const l = Number(r.l);
+    if (Number.isFinite(h) && h > high) high = h;
+    if (Number.isFinite(l) && l < low) low = l;
   }
+
+  if (!Number.isFinite(high) || !Number.isFinite(low)) return null;
+  return { high, low };
 }
 
 // Short interest and short volume
 
 export async function getShortInterest(ticker: string): Promise<any> {
   if (!ticker) throw new Error('ticker is required');
-  const apiKey = getApiKey();
-  // Polygon docs: https://polygon.io/docs/rest/stocks/fundamentals/short-interest
-  const url = `${BASE}/stocks/v1/short-interest`;
-  try {
-    const res = await axios.get(url, {
-      params: { apiKey, ticker },
-      timeout: REQUEST_TIMEOUT,
-    });
-    const results = res.data?.results;
-    return Array.isArray(results) ? results[0] ?? null : results ?? null;
-  } catch (err: any) {
-    if (err.response) {
-      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
-      const e: any = new Error(msg);
-      e.status = err.response.status;
-      throw e;
-    }
-    throw err;
-  }
+  const data = await polygonGet('/stocks/v1/short-interest', { ticker });
+  const results = data?.results;
+  return Array.isArray(results) ? results[0] ?? null : results ?? null;
 }
 
 export async function getShortVolume(ticker: string, date: string): Promise<any> {
   if (!ticker) throw new Error('ticker is required');
   if (!date) throw new Error('date is required (YYYY-MM-DD)');
-  const apiKey = getApiKey();
-  // Polygon docs: https://polygon.io/docs/rest/stocks/fundamentals/short-volume
-  const url = `${BASE}/stocks/v1/short-volume`;
-  try {
-    const res = await axios.get(url, {
-      params: { apiKey, ticker, date },
-      timeout: REQUEST_TIMEOUT,
-    });
-    const results = res.data?.results;
-    return Array.isArray(results) ? results[0] ?? null : results ?? null;
-  } catch (err: any) {
-    if (err.response) {
-      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
-      const e: any = new Error(msg);
-      e.status = err.response.status;
-      throw e;
-    }
-    throw err;
-  }
+  const data = await polygonGet('/stocks/v1/short-volume', { ticker, date });
+  const results = data?.results;
+  return Array.isArray(results) ? results[0] ?? null : results ?? null;
 }
 
 /**
@@ -336,24 +216,9 @@ export async function getSharesOutstanding(ticker: string): Promise<number | nul
  */
 export async function getFinancials(ticker: string): Promise<any> {
   if (!ticker) throw new Error('ticker is required');
-  const apiKey = getApiKey();
-  const url = `${BASE}/vX/reference/financials`;
-  try {
-    const res = await axios.get(url, {
-      params: { apiKey, ticker, limit: 1 },
-      timeout: REQUEST_TIMEOUT,
-    });
-    const results = res.data?.results;
-    return Array.isArray(results) ? results[0] ?? null : results ?? null;
-  } catch (err: any) {
-    if (err.response) {
-      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
-      const e: any = new Error(msg);
-      e.status = err.response.status;
-      throw e;
-    }
-    throw err;
-  }
+  const data = await polygonGet('/vX/reference/financials', { ticker, limit: 1 });
+  const results = data?.results;
+  return Array.isArray(results) ? results[0] ?? null : results ?? null;
 }
 
 /**
@@ -369,23 +234,8 @@ export async function getFinancialsHistory(
   limit = 10,
 ): Promise<any[]> {
   if (!ticker) throw new Error('ticker is required');
-  const apiKey = getApiKey();
-  const url = `${BASE}/vX/reference/financials`;
-  try {
-    const res = await axios.get(url, {
-      params: { apiKey, ticker, timeframe, limit },
-      timeout: REQUEST_TIMEOUT,
-    });
-    const results: any[] = Array.isArray(res.data?.results) ? res.data.results : [];
-    // Sort by end_date descending so index 0 is the most recent filing
-    return results.sort((a, b) => new Date(b.end_date).getTime() - new Date(a.end_date).getTime());
-  } catch (err: any) {
-    if (err.response) {
-      const msg = `Polygon API error: ${err.response.status} ${err.response.statusText} - ${JSON.stringify(err.response.data)}`;
-      const e: any = new Error(msg);
-      e.status = err.response.status;
-      throw e;
-    }
-    throw err;
-  }
+  const data = await polygonGet('/vX/reference/financials', { ticker, timeframe, limit });
+  const results: any[] = Array.isArray(data?.results) ? data.results : [];
+  // Sort by end_date descending so index 0 is the most recent filing
+  return results.sort((a, b) => new Date(b.end_date).getTime() - new Date(a.end_date).getTime());
 }


### PR DESCRIPTION
## Summary
- add reusable `polygonGet` helper for Polygon API calls
- refactor Polygon client to use shared request handler

## Testing
- `npm test` *(fails: Maximum number of redirects exceeded)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_b_68a8880464a4832093b61ae81f1231fc