### PR TITLE
feat: project share price from signals

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,14 +50,17 @@ async function main(): Promise<void> {
 
     const BATCH_SIZE = 5;
     const results = await mapBatched(tickers, BATCH_SIZE, async (symbol) => {
-      const signals = await generateSignals(symbol, date);
+      const { price, projectedPrice, signals } = await generateSignals(symbol, date);
       const score = aggregateSignalScore(signals);
-      return { symbol, signals, score };
+      return { symbol, price, projectedPrice, signals, score };
     });
 
-    results.forEach(({ symbol, signals, score }) => {
+    results.forEach(({ symbol, price, projectedPrice, signals, score }) => {
       console.log(`\n${symbol} signals:`, signals);
       console.log(`Total score: ${score}`);
+      if (typeof price === 'number' && typeof projectedPrice === 'number') {
+        console.log(`Projected Price: ${projectedPrice.toFixed(2)} (current: ${price.toFixed(2)})`);
+      }
     });
 
     const sorted = results.slice().sort((a, b) => b.score - a.score);


### PR DESCRIPTION
## Summary
- add daily momentum indicator and compute projected share price from aggregated signals
- surface projected price alongside current price in main output

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: Maximum number of redirects exceeded)*

------
https://chatgpt.com/codex/tasks/task_b_68a8a496af9483208100a4da3cb5fe5e